### PR TITLE
Fixes auto-succeeding pester tests in AboutComparison and AboutString…

### DIFF
--- a/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutComparison.Koans.ps1
@@ -22,7 +22,7 @@ Describe 'Comparison Operators' {
 
         It 'is a simple test' {
             $true -eq $false | Should -Be $false
-            __ | Should -Be (1 -eq 1)
+            $____ | Should -Be (1 -eq 1)
         }
 
         It 'will attempt to convert types' {
@@ -168,8 +168,8 @@ Describe 'Logical Operators' {
 
         It 'returns $true if either input is $true' {
             $true -or $false | Should -Be $true
-            __ | Should -Be ($false -or $true)
-            __ | Should -Be ($true -or $true)
+            $____ | Should -Be ($false -or $true)
+            $____ | Should -Be ($true -or $true)
         }
 
         It 'may coerce values to boolean' {
@@ -193,7 +193,7 @@ Describe 'Logical Operators' {
 
         It 'negates a boolean value' {
             -not $true | Should -Be $false
-            __ | Should -Be (-not $false)
+            $____ | Should -Be (-not $false)
         }
 
         It 'can be shortened to !' {

--- a/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
+++ b/PSKoans/Koans/Foundations/AboutStrings.Koans.ps1
@@ -102,7 +102,7 @@ Describe 'Strings' {
 
         It 'adds strings together' {
             # Two become one.
-            $String1 = 'This string'
+            $String1 = '_____'
             $String2 = 'is cool.'
 
             $String1 + ' ' + $String2 | Should -Be 'This string is cool.'


### PR DESCRIPTION
…s (#214)

* Fixed "adds strings together" 

It "adds strings together" was passing the pester test without user input. Replaced the contents of $String1 with '__' so the user can solve it.

* Fixed It's that are autopassing the pester tests

Auto-passing tests:
It 'is a simple test'
It 'returns $true if either input is $true'
It 'negates a boolean value'
In all three instances, __ evaluates to $true, which causes the tests to pass. 

I replaced __ with $__ in these instances to make sure the tests fail.

* Updated $__ to $____ 

Added two extra underscores to each $__ to make sure no one will confuse $__ for $_

* Update PSKoans/Koans/Foundations/AboutStrings.Koans.ps1

Longer blanks! Better blanks!

Co-Authored-By: Joel Sallow (/u/ta11ow) <32407840+vexx32@users.noreply.github.com>

﻿# PR Summary

<!--
Include a brief synopsis of the changes in this section, just outside this comment block.
If this Pull Request resolves an outstanding issue, please mention this in the body of the pull request, in one of the following formats, referencing the issue number directly:

Fixes #999
Resolves #999

For more alternatives, see: https://help.github.com/en/articles/closing-issues-using-keywords
-->

## Context

<!-- Detail the context of the PR, any particularly relevant discussions in related issues (linking to comments where appropriate), and the general reason the PR is being submitted / what the goal is. -->

## Changes

<!-- List any and all changes here, in bullet point form. -->

## Checklist

- [ ] Pull Request has a meaningful title.
- [ ] Summarised changes.
- [ ] Pull Request is ready to merge & is not WIP.
- [ ] Added tests / only testable interactively.
  - Make sure you add a new test if old tests do not effectively test the code changed.
- [ ] Added documentation / opened issue to track adding documentation at a later date.
